### PR TITLE
Addition of new functionality for creating / removing prefix filters

### DIFF
--- a/pyVMC.py
+++ b/pyVMC.py
@@ -1492,18 +1492,19 @@ def getSDDCT0PrefixLists(csp_url, session_token):
             print(prefixlisttable)
             prefixtable = PrettyTable(['Sequence','Network','Comparison', 'Action'])
             i = 0
-            for prefix in prefixlist['prefixes']:
-                i+=1
-                if prefix.get('ge'):
-                    comparison = "ge (greater-than-or-equal)"
-                elif prefix.get('le'):
-                    comparison = "le (less-than-or-equal)"
-                else:
-                    comparison = '-'
-                prefixtable.add_row([i,prefix['network'],comparison,prefix['action']])
-            print(f'PREFIX ENTRIES FOR {prefixlist["id"]}:')
-            print(prefixtable)
-            print("")
+            if prefixlist.get('prefixes'):
+                for prefix in prefixlist['prefixes']:
+                    i+=1
+                    if prefix.get('ge'):
+                        comparison = "ge (greater-than-or-equal)"
+                    elif prefix.get('le'):
+                        comparison = "le (less-than-or-equal)"
+                    else:
+                        comparison = '-'
+                    prefixtable.add_row([i,prefix['network'],comparison,prefix['action']])
+                print(f'PREFIX ENTRIES FOR {prefixlist["id"]}:')
+                print(prefixtable)
+                print("")
 
         if len(sys.argv) == 3:
             if sys.argv[2] == "showjson":

--- a/pyVMC.py
+++ b/pyVMC.py
@@ -1513,6 +1513,72 @@ def getSDDCT0PrefixLists(csp_url, session_token):
     else:
         print (f'API call failed with status code {response.status_code}. URL: {myURL}.')
 
+def newBGPprefixlist(csp_url, session_token):
+#    myHeader = {'csp-auth-token': session_token}
+    myHeader = {'Authorization': f'Bearer {session_token}', 'Content-type': 'application/json'}
+#   capture details for new prefix list
+    description= input('Enter a description name for the prefix list:  ')
+    display_name= input('Enter a display name for the prefix list:  ')
+    prefix_list_id= input('Enter an ID string for the prefix list:  ')
+#   create python dictionary to contain the prefix list
+    prefix_list = {}
+    prefix_list['description'] = description
+    prefix_list["display_name"] = display_name
+    prefix_list["id"] = prefix_list_id
+    prefix_list["prefixes"] = []
+    myURL = f'{csp_url}/policy/api/v1/infra/tier-0s/vmc/prefix-lists/' + prefix_list_id
+#   print(myURL)
+#   append individual prefixes to the list
+#   begin input loop
+    test = ''
+    while test != 'f':
+        test=input('What would you like to do? New prefix (n) / Review list (r) / Finish (f) / Abort (a)')
+        if test== "n":
+#           capture details of new prefix from user
+            cidr = input('Enter a network or IP address in CIDR format:  ')
+            action= input('Enter the action (PERMIT or DENY):  ')
+            scope= input('Optional - Enter either le or ge:  ')
+            length= int(input('Optional - Enter the length of the mask to apply:  '))
+#           build new prefix as unique dictionary
+            new_prefix = {}
+            new_prefix["action"] = action
+            new_prefix[scope] = length
+            new_prefix["network"] = cidr
+#           append new prefix to list of prefixes in prefix_list
+            prefix_list["prefixes"].append(new_prefix)
+        elif test == "r":
+            print("Please review the prefix list carefully... be sure you are not going to block all traffic!")
+            print(prefix_list)
+        elif test == 'f':
+#            json_data = json.dumps(prefix_list)
+#            print(json_data)
+#            response = requests.patch(myURL, headers=myHeader, json=json_data)
+            response = requests.patch(myURL, headers=myHeader, json=prefix_list)
+#            json_response_status_code = response.status_code
+            if response.status_code == 200:
+                print("prefix list added")
+            else:
+                print(response.status_code)
+                print(response.json())
+                print()
+        elif test == 'a':
+            break
+        else:
+            print("Incorrect syntax. Please use 'n,' 'r,' 'f' or 'a' - Try again or check the help.")
+
+def removeBPGprefixlist(csp_url, session_token, prefix_list_id):
+    myHeader = {'csp-auth-token': session_token}
+    myURL = f'{csp_url}/policy/api/v1/infra/tier-0s/vmc/prefix-lists/' + prefix_list_id
+    print(myURL)
+    response = requests.delete(myURL, headers=myHeader)
+    json_response = response.status_code
+    print(json_response)
+    if json_response == 200 :
+        print("The BGP prefix list " + prefix_list_id + " has been deleted")
+    else :
+        print("There was an error. Try again.")
+    return json_response
+
 def getSDDCT0BGPneighbors(csp_url, session_token):
     myHeader = {'csp-auth-token': session_token}
     myURL = f'{csp_url}/policy/api/v1/infra/tier-0s/vmc/locale-services/default/bgp/neighbors'
@@ -1740,6 +1806,10 @@ def getHelp():
     print("\tshow-t0-bgp-neighbors [showjson]")
     print("\nTo show T0 prefix lists:")
     print("\tshow-t0-prefix-lists [showjson]")
+    print("\nTo create a new T0 BGP Prefix List")
+    print("\tnew-t0-prefix-list")
+    print("\nTo remove a T0 BGP Prefix List")
+    print("\tremove-t0-prefix-list [PREFIX LIST ID] - you can see current prefix list with 'show-t0-prefix-lists'")
 
 # --------------------------------------------
 # ---------------- Main ----------------------
@@ -1772,6 +1842,11 @@ elif intent_name == "show-t0-bgp-neighbors":
     getSDDCT0BGPneighbors(proxy, session_token)
 elif intent_name == "show-t0-prefix-lists":
     getSDDCT0PrefixLists(proxy, session_token)    
+elif intent_name == "new-t0-prefix-list":
+    newBGPprefixlist(proxy, session_token)
+elif intent_name == "remove-t0-prefix-list":
+    prefix_list_id = sys.argv[2]
+    removeBPGprefixlist(proxy, session_token, prefix_list_id)
 elif intent_name == "show-egress-interface-counters":
     edge_cluster_id = getSDDCEdgeCluster(proxy, session_token)
     edge_path_0 = getSDDCEdgeNodes(proxy, session_token, edge_cluster_id, 0)


### PR DESCRIPTION
added 2 new functions:

1. creating / uploading prefix filters using PATCH
Added new function to prompt for user input and create prefix filters, which may then be uploaded to customer SDDC.   This is to avoid the use of RAW REST API and postman, making it easier / faster to customize networking in the SDDC.  Function includes the ability to abort / abandon in the event the user makes a mistake with their filter.  ... future capability will include attaching filters to BGP neighbors; this functionality is not yet included.

2. removing prefix filters
Added a new function to remove prefix filters from the SDDC.

Testing was performed using a temporary SDDC deployed for the purpose of testing this specific functionality.  Results were compared with similar functions using POSTman to ensure correct behavior.
