### PR TITLE
Add 2 service role commands

### DIFF
--- a/pyVMC.py
+++ b/pyVMC.py
@@ -1357,6 +1357,27 @@ def getCSPServiceRoles(csp_url, session_token):
         for svc_role in svc_def['serviceRoleNames']:
             print(svc_role)
 
+def findCSPUserByServiceRole(csp_url, session_token):
+    myHeader = {'csp-auth-token': session_token}
+    if len(sys.argv) < 2:
+        print('Usage: find-user-by-service-role [role]')
+        sys.exit()
+
+    role_name= sys.argv[2]
+    myURL = csp_url + f'/csp/gateway/am/api/v2/orgs/{ORG_ID}/users'
+    response = requests.get(myURL,headers=myHeader)
+    json_response = response.json()
+    users = json_response['results']
+    grouprolelist = []
+    for user in users:
+        for servicedef in user['serviceRoles']:
+            for role in servicedef['serviceRoles']:
+                if role['name'] == role_name:
+                    display_role = ''
+                    for orgrole in user['organizationRoles']:
+                        display_role = display_role + orgrole['name'] + ' '
+                    print(user['user']['email'], '-', role_name, '-',  display_role) 
+
 def getCSPGroupDiff(csp_url, session_token):
     myHeader = {'csp-auth-token': session_token}
     if len(sys.argv) < 3:
@@ -1852,6 +1873,8 @@ elif intent_name == "show-csp-org-users":
     getCSPOrgUsers(strCSPProdURL,session_token)
 elif intent_name == "show-csp-service-roles":
     getCSPServiceRoles(strCSPProdURL,session_token)
+elif intent_name == "find-csp-user-by-service-role":
+    findCSPUserByServiceRole(strCSPProdURL,session_token)
 elif intent_name == "show-t0-routes":
     getSDDCT0routes(proxy,session_token)
 elif intent_name == "show-t0-bgp-neighbors":

--- a/pyVMC.py
+++ b/pyVMC.py
@@ -1346,6 +1346,17 @@ def addUsersToCSPGroup(csp_url, session_token):
         print(f"Failed: {response_json['failed']}" )
     else:
         print (f'Operation failed with status code {response.status_code}. URL: {myURL}. Body: {params}')
+
+def getCSPServiceRoles(csp_url, session_token):
+    myHeader = {'csp-auth-token': session_token}
+    myURL = csp_url + f'/csp/gateway/am/api/loggedin/user/orgs/{ORG_ID}/service-roles'
+    response = requests.get(myURL,headers=myHeader)
+    json_response = response.json()
+    #print(json.dumps(json_response, indent=4))
+    for svc_def in json_response['serviceRoles']:
+        for svc_role in svc_def['serviceRoleNames']:
+            print(svc_role)
+
 def getCSPGroupDiff(csp_url, session_token):
     myHeader = {'csp-auth-token': session_token}
     if len(sys.argv) < 3:
@@ -1695,6 +1706,8 @@ def getHelp():
     print("\tshow-csp-group-diff [GROUP_ID] [showall|skipmembers|skipowners]")
     print("\nTo show a CSP user:")
     print("\tshow-csp-org-users [email]")
+    print("\nTo show CSP service roles for the currently logged in user:")
+    print("\tshow-csp-service-roles")
     print("\nTo show the CGW security rules:")
     print("\tshow-cgw-rule")
     print("\nTo create a new CGW security rule")
@@ -1837,6 +1850,8 @@ elif intent_name == "show-csp-group-members":
         getCSPGroupMembers(strCSPProdURL,session_token)
 elif intent_name == "show-csp-org-users":
     getCSPOrgUsers(strCSPProdURL,session_token)
+elif intent_name == "show-csp-service-roles":
+    getCSPServiceRoles(strCSPProdURL,session_token)
 elif intent_name == "show-t0-routes":
     getSDDCT0routes(proxy,session_token)
 elif intent_name == "show-t0-bgp-neighbors":


### PR DESCRIPTION
Adds show-csp-service-roles - display all service roles assigned to the currently logged in user
Adds find-csp-user-by-service-role - Ability to search for all users that are assigned a particular service role. For example, show me all users who have the vmc-user:full role