### PR TITLE
feature: attach-t0-prefix list, detach-t0-prefix-list

### DIFF
--- a/pyVMC.py
+++ b/pyVMC.py
@@ -1615,13 +1615,9 @@ def attachT0BGPprefixlist(csp_url, session_token, prefix_list_id, route_filter_d
     if response.status_code == 200:
         json_response = response.json()
         neighbor_json = json_response
-        del neighbor_json['_create_time']
-        del neighbor_json['_create_user']
-        del neighbor_json['_last_modified_time']
-        del neighbor_json['_last_modified_user']
-        del neighbor_json['_system_owned']
-        del neighbor_json['_protection']
-        del neighbor_json['_revision']
+        for key in list(neighbor_json.keys()):
+            if key.startswith('_'):
+                del neighbor_json[key]
         neighbor_json['route_filtering'] = [{'enabled': True, 'address_family': 'IPV4', direction: ['/infra/tier-0s/vmc/prefix-lists/' + prefix_list_id]}]
         response = requests.patch(myURL, headers=myHeader, json = neighbor_json)
         if response.status_code == 200:
@@ -1640,13 +1636,9 @@ def detachT0BGPprefixlists(csp_url, session_token, neighbor_id):
     if response.status_code == 200:
         json_response = response.json()
         neighbor_json = json_response
-        del neighbor_json['_create_time']
-        del neighbor_json['_create_user']
-        del neighbor_json['_last_modified_time']
-        del neighbor_json['_last_modified_user']
-        del neighbor_json['_system_owned']
-        del neighbor_json['_protection']
-        del neighbor_json['_revision']
+        for key in list(neighbor_json.keys()):
+            if key.startswith('_'):
+                del neighbor_json[key]
         neighbor_json['route_filtering'] = [{'enabled': True, 'address_family': 'IPV4'}]
         response = requests.patch(myURL, headers=myHeader, json = neighbor_json)
         if response.status_code == 200:

--- a/pyVMC.py
+++ b/pyVMC.py
@@ -1676,7 +1676,6 @@ def getSDDCT0BGPneighbors(csp_url, session_token):
     if response.status_code == 200:
         json_response = response.json()
         bgp_neighbors = json_response['results']
-        print(bgp_neighbors)
         bgp_table = PrettyTable(['ID','Remote AS Num','Remote Address','In_route_filter','Out_route_filter'])
         for neighbor in bgp_neighbors:
             if neighbor.get("in_route_filters"):

--- a/pyVMC.py
+++ b/pyVMC.py
@@ -1676,26 +1676,17 @@ def getSDDCT0BGPneighbors(csp_url, session_token):
     if response.status_code == 200:
         json_response = response.json()
         bgp_neighbors = json_response['results']
-        bgp_table = PrettyTable(['ID','Remote AS Num','Remote Address'])
+        print(bgp_neighbors)
+        bgp_table = PrettyTable(['ID','Remote AS Num','Remote Address','In_route_filter','Out_route_filter'])
         for neighbor in bgp_neighbors:
-            bgp_table.add_row([neighbor['id'],neighbor['remote_as_num'],neighbor['neighbor_address']])
+            if neighbor.get("in_route_filters"):
+                bgp_table.add_row([neighbor['id'],neighbor['remote_as_num'],neighbor['neighbor_address'],neighbor['in_route_filters'], "-"])
+            elif neighbor.get("out_route_filters"):
+                bgp_table.add_row([neighbor['id'],neighbor['remote_as_num'],neighbor['neighbor_address'],"-",neighbor['out_route_filters'],])
+            else:
+                bgp_table.add_row([neighbor['id'],neighbor['remote_as_num'],neighbor['neighbor_address'],"-", "-"])
         print('NEIGHBORS:')
         print(bgp_table)
-        filter_table = PrettyTable(['Enabled','Address Family','Out Filter','In Filter'])
-        if neighbor.get("route_filtering"):
-            for filter in neighbor['route_filtering']:
-                if filter.get('out_route_filters'):
-                    out_route_filters = filter['out_route_filters']
-                else:
-                    out_route_filters = "-"
-
-                if filter.get('in_route_filters'):
-                        in_route_filters = filter['in_route_filters']
-                else:
-                    in_route_filters = "-"
-                filter_table.add_row([filter['enabled'],filter['address_family'],out_route_filters,in_route_filters])
-            print("FILTERS:")
-            print (filter_table)
         if len(sys.argv) == 3:
             if sys.argv[2] == "showjson":
                 print('RAW JSON:')


### PR DESCRIPTION
**New features:** 
- _attach-t0-prefix-list_: this will attach a specified prefix list to either the in_route_filter or the out_route_filter for the specified T0 BGP neighbor
- _detach-t0-prefix-lists_: this will detach all prefix lists from the the specified T0 BGP neighbor

tested on existing test SDDC

Signed-off-by: Tom Twyman <ttwyman@vmware.com>