### PR TITLE
Bug: updated error handling for new and empty values for new-t0-prefix-list

### DIFF
--- a/pyVMC.py
+++ b/pyVMC.py
@@ -1580,15 +1580,17 @@ def newBGPprefixlist(csp_url, session_token):
         test=input('What would you like to do? ')
         if test== "2":
 #           capture details of new prefix from user
-            cidr = input('Enter a network or IP address in CIDR format:  ')
+            cidr = input('Enter 'ANY' or a network or IP address in CIDR format:  ')
             action= input('Enter the action (PERMIT or DENY):  ')
             scope= input('Optional - Enter either le or ge:  ')
-            length= int(input('Optional - Enter the length of the mask to apply:  '))
+            if scope != "":
+                length= int(input('Required - Enter the length of the mask to apply:  '))
 #           build new prefix as unique dictionary
             new_prefix = {}
             new_prefix["action"] = action
-            new_prefix[scope] = length
             new_prefix["network"] = cidr
+            if scope !="" and length != "":
+                new_prefix[scope] = length
 #           append new prefix to list of prefixes in prefix_list
             prefix_list["prefixes"].append(new_prefix)
         elif test == "3":

--- a/pyVMC.py
+++ b/pyVMC.py
@@ -1580,11 +1580,15 @@ def newBGPprefixlist(csp_url, session_token):
         test=input('What would you like to do? ')
         if test== "2":
 #           capture details of new prefix from user
-            cidr = input('Enter 'ANY' or a network or IP address in CIDR format:  ')
+            cidr = input('Enter "ANY" or a network or IP address in CIDR format:  ')
             action= input('Enter the action (PERMIT or DENY):  ')
-            scope= input('Optional - Enter either le or ge:  ')
-            if scope != "":
-                length= int(input('Required - Enter the length of the mask to apply:  '))
+            if action == "PERMIT" or action == "DENY":
+                scope= input('Optional - Enter either le or ge:  ')
+                if scope != "":
+                    length= int(input('Required - Enter the length of the mask to apply:  '))
+            else:
+                print('Action must be either "PERMIT" or "DENY"')
+                break
 #           build new prefix as unique dictionary
             new_prefix = {}
             new_prefix["action"] = action


### PR DESCRIPTION
- updated verbiage to indicate "ANY" is permissible network
- updated logic and error handling for optional values for "scope" and "length in new prefix

tested on multiple SDDC with multiple testers