### PR TITLE
Feature: add show-t0-bgp-routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Here are the currently supported commands:
     - show-t0-bgp-neighbors: show T0 BGP neighbors
     - show-t0-prefix-lists: show T0 prefix lists
     - show-t0-routes: show routes at the T0 router
+    - show-t0-bgp-routes: show learned and advertised routes via BGP
 
 - DNS
     - show-dns-services: show DNS services


### PR DESCRIPTION
Added functionality to show learned and advertised routes via BGP.  Runs as a single command and returns two separate tables, one for learned routes and one for advertised routes.  