### PR TITLE
Adding support for OAuth auth

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -4,6 +4,10 @@ strCSPProdURL   = https://console.cloud.vmware.com
 strVCDRProdURL =  https://vcdr-xxx-xxx-xxx-xxx.app.vcdr.vmware.com/
 
 refresh_Token   = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+#OR
+oauth_clientId  = xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+oauth_clientSecret = xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
 org_id          = xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 sddc_id         = xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 


### PR DESCRIPTION
- For API use that is not associated with an individual, such as automation solutions, it is best not to use an API token associated with an individual account, in case that individual is not available when the token expires, they change roles or leave the organization, which can affect the services using that token. 
- Instead,  the Organization owner can create an OAuth App that consists of both an App ID and App Secret to provide access to the API.
- For more details please refer https://vmc.techzone.vmware.com/resource/tech-reference-vmware-cloud-intro-api#oauth-app

Signed-off-by: Mandar Bapat [bapatm@vmware.com](mailto:bapatm@vmware.com)