### PR TITLE
Fixed create-sddc-group and get-task-status

### DIFF
--- a/pyVMC.py
+++ b/pyVMC.py
@@ -750,9 +750,7 @@ def main():
     create_sddc_group_parser=vtc_parser_subs.add_parser('create-sddc-group', parents = [auth_flag, vmc_url_flag,org_id_flag,sddc_id_parser_flag], help = 'Create an SDDC group')
     create_sddc_group_parser.add_argument("-n","--name", required=True, help= "The Name for the SDDC Group")
     create_sddc_group_parser.add_argument("-desc","--description", help= "The Description for the SDDC Group. please make sure to enclose this in quotes if your description has spaces in it")
-    create_sddc_group_parser.add_argument("-d","--deployment_groups", nargs='*', default=[], help="Pass in the deployment IDs to be added to the cluster. Use 0-n times.")
-    create_sddc_group_parser.add_argument("-nowait","--dont-wait", action='store_true',required=False, help= "Don't wait on the result. Show the task ID")
-    create_sddc_group_parser.add_argument("-v","--verbose", action='store_true', required=False, help= "Show verbose output")
+    create_sddc_group_parser.add_argument("-d","--deployment_groups", nargs='*', required = True, help="Space-separated list of deployment IDs to be added to the cluster; at least one is required. Use get-deployments for a list.")
     create_sddc_group_parser.set_defaults(func = create_sddc_group)
 
     delete_sddc_group_parser=vtc_parser_subs.add_parser('delete-sddc-group', parents = [auth_flag, vmc_url_flag,org_id_flag], help = 'Delete an SDDC group')

--- a/pyVMC.py
+++ b/pyVMC.py
@@ -688,7 +688,7 @@ def main():
 
     get_task_status_parser = vtc_parser_subs.add_parser('get-task-status', parents=[auth_flag,vmc_url_flag,org_id_flag], help = 'Get status of the current task.')
     get_task_status_parser.add_argument('-tid','--task_id', required=True, help="The ID of the task for which you would like the status.")
-    get_task_status_parser.add_argument('-v','--verbose', action='store_false', help="Additional information printed during task.")
+    get_task_status_parser.add_argument('-v','--verbose', action='store_true', help="Additional information printed during task.")
     get_task_status_parser.set_defaults(func = get_task_status)
 # ============================
 # VTC - AWS Operations

--- a/pyvmc_fxns.py
+++ b/pyvmc_fxns.py
@@ -1316,19 +1316,21 @@ def get_resource_id(**kwargs):
 
 def create_sddc_group(**kwargs):
     strProdURL = kwargs['strProdURL']
+    org_id = kwargs['ORG_ID']
+    session_token = kwargs['sessiontoken']
+
     name = kwargs['name']
-    if "deployment_groups" not in kwargs:
-        deployment_groups = None
+    description = kwargs['description']
+    members = []
+    if kwargs['deployment_groups'] is not None:
+        for i in kwargs['deployment_groups']:
+            d = {"id" : i}
+            members.append(d)
     else:
-        deployment_groups = kwargs['deployment_groups']
-    org_id = kwargs["ORG_ID"]
-    session_token = kwargs["sessiontoken"]
-    description = kwargs["description"]
- 
-    json_response = create_sddc_group_json(strProdURL, name, description, deployment_groups, org_id, session_token)
+        pass
+    json_response = create_sddc_group_json(strProdURL, name, description, members, org_id, session_token)
     if json_response == None:
         sys.exit(1)
-    
     task_id = json_response ['operation_id']
     print(f"The task id for the SSDC group {name} creation is: {task_id}. Use get-task-status for updates.")
 

--- a/pyvmc_vmc.py
+++ b/pyvmc_vmc.py
@@ -682,18 +682,10 @@ def get_task_status_json(strProdURL,task_id, org_id, session_token):
 # VTC - SDDC Group Operations
 # ============================
 
-def buildDeploymentIdList(deploymentList: list) -> list:
-    '''Quick function to build up list'''
-    retlist = []
-    for i in deploymentList:
-        d = {"id" : i}
-        retlist.append(d)
-    return retlist
-
 #
 #  No documentation. Use the API explorer.
 #
-def create_sddc_group_json(strProdURL, name, description, deployment_groups, org_id, session_token):
+def create_sddc_group_json(strProdURL, name, description, members, org_id, session_token):
     """Create an SDDC group"""
     myHeader = {'csp-auth-token': session_token}
  
@@ -701,22 +693,14 @@ def create_sddc_group_json(strProdURL, name, description, deployment_groups, org
     body = {
         "name": name,
         "description": description,
-        "members": buildDeploymentIdList(deployment_groups)
+        "members": members
     }
-    # 
     response = requests.post(myURL, json=body, headers=myHeader)
-    if response.status_code == 504:
-        print("API returned with 504 error code. Check your permissions and network routes")
-        return None
-
     json_response = response.json()
     if response.status_code == 200:
         return json_response
     else:
-        print("There was an error. Check the syntax.")
-        print(f'API call failed with status code {response.status_code}. URL: {myURL}.')
-        if 'error_message' in json_response:
-            print(json_response['error_message'])
+        vmc_error_handling(response)
         return None
 
 def delete_sddc_group_json(strProdURL, resource_id, org_id, session_token):


### PR DESCRIPTION
- corrected verbose parameter options for get-task-status
- removed extraneous arguments for create-sddc-group
- simplified logic for creating sddc members in create-sddc-group